### PR TITLE
Get rid of HISTORY.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,6 @@ from setuptools import setup, find_packages
 with open('README.md') as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.md') as history_file:
-    history = history_file.read()
-
 requirements = [
     'Click>=6.0',
     'python-jose==3.0.1'
@@ -42,7 +39,7 @@ setup(
         ],
     },
     install_requires=requirements,
-    long_description=readme + '\n\n' + history,
+    long_description=readme,
     include_package_data=True,
     keywords='federated_aws_cli',
     name='federated_aws_cli',


### PR DESCRIPTION
Let's move to CHANGELOG.md after we have the first version
https://keepachangelog.com/en/0.3.0/#what-should-the-change-log-file-be-named