### PR TITLE
Add get_security_audit_role_arns function

### DIFF
--- a/cloudformation/functions/get_group_role_map.py
+++ b/cloudformation/functions/get_group_role_map.py
@@ -10,7 +10,7 @@ def get_paginated_results(
     product: str,
     action: str,
     key: str,
-    credentials: SimpleDict = None,
+    client_args: SimpleDict = None,
     action_args: SimpleDict = None,
 ) -> list:
     """Paginate through AWS API responses, combining them into a list
@@ -18,18 +18,18 @@ def get_paginated_results(
     :param str product: AWS product name
     :param str action: AWS API action name
     :param str key: The parent key in the paginated response
-    :param dict credentials: Optional AWS API credentials
+    :param dict client_args: Optional AWS API credentials
     :param dict action_args: Optional additional arguments to pass to action
                              method
     :return: list of responses from all pages
     """
     action_args = {} if action_args is None else action_args
-    credentials = {} if credentials is None else credentials
+    client_args = {} if client_args is None else client_args
     return [
         response_element
         for sublist in [
             api_response[key]
-            for api_response in boto3.client(product, **credentials)
+            for api_response in boto3.client(product, **client_args)
             .get_paginator(action)
             .paginate(**action_args)
         ]

--- a/cloudformation/functions/get_security_audit_role_arns.py
+++ b/cloudformation/functions/get_security_audit_role_arns.py
@@ -1,0 +1,37 @@
+from typing import List
+from .get_group_role_map import get_paginated_results
+
+# AWS Account : infosec-prod
+TABLE_CATEGORY = 'AWS Security Auditing Service'
+TABLE_INDEX_NAME = 'category'
+TABLE_ATTRIBUTE_NAME = 'SecurityAuditIAMRoleArn'
+TABLE_NAME = 'cloudformation-stack-emissions'
+TABLE_REGION = 'us-west-2'
+
+
+def get_security_audit_role_arns() -> List[str]:
+    """Fetch list ARNs of security auditing IAM Roles
+
+    :return: List of ARNs
+    """
+    action_args = {
+        'TableName': TABLE_NAME,
+        'IndexName': TABLE_INDEX_NAME,
+        'Select': 'SPECIFIC_ATTRIBUTES',
+        'ProjectionExpression': TABLE_ATTRIBUTE_NAME,
+        'KeyConditionExpression': '#c = :v',
+        'ExpressionAttributeNames': {'#c': TABLE_INDEX_NAME},
+        'ExpressionAttributeValues': {':v': {'S': TABLE_CATEGORY}},
+    }
+    items = get_paginated_results(
+        'dynamodb',
+        'query',
+        'Items',
+        {'region_name': TABLE_REGION},
+        action_args,
+    )
+    return [
+        x[TABLE_ATTRIBUTE_NAME]['S']
+        for x in items
+        if TABLE_ATTRIBUTE_NAME in x
+    ]

--- a/cloudformation/functions/tests/test_get_secuity_audit_role_arns.py
+++ b/cloudformation/functions/tests/test_get_secuity_audit_role_arns.py
@@ -1,0 +1,104 @@
+import boto3
+from moto import mock_dynamodb2
+from ..get_security_audit_role_arns import get_security_audit_role_arns
+from ..get_security_audit_role_arns import (
+    TABLE_CATEGORY,
+    TABLE_INDEX_NAME,
+    TABLE_ATTRIBUTE_NAME,
+    TABLE_NAME,
+    TABLE_REGION,
+)
+
+# https://github.com/mozilla/cloudformation-cross-account-outputs/blob/master/cloudformation/cloudformation-stack-emissions-dynamodb.yml
+TABLE_PRIMARY_HASH_ATTRIBUTE = 'aws-account-id'
+TABLE_PRIMARY_RANGE_ATTRIBUTE = 'id'
+TABLE_SECONDARY_HASH_ATTRIBUTE = TABLE_INDEX_NAME
+TABLE_SECONDARY_RANGE_ATTRIBUTE = TABLE_PRIMARY_RANGE_ATTRIBUTE
+
+# Test values
+AWS_ACCOUNT_ID = '123456789012'
+IAM_ROLE_NAME = (
+    'InfosecClientRoleSecurity-InfosecSecurityAuditRole-ABCDEFGHIJKLM'
+)
+IAM_ROLE_ARN = 'arn:aws:iam::{}:role/{}'.format(AWS_ACCOUNT_ID, IAM_ROLE_NAME)
+STACK_ID = '12345678-90ab-cdef-1234-567890abcdef'
+LOGICAL_RESOURCE_ID = 'PublishInfosecSecurityAuditRoleArnToSNS'
+
+
+def create_dynamodb_table():
+    """Create a mocked CloudFormation Cross Account Output DynamoDB table
+
+    https://github.com/mozilla/cloudformation-cross-account-outputs/blob/master/cloudformation/cloudformation-stack-emissions-dynamodb.yml
+    """
+    client = boto3.client('dynamodb', region_name=TABLE_REGION)
+    client.create_table(
+        AttributeDefinitions=[
+            {
+                'AttributeName': TABLE_PRIMARY_HASH_ATTRIBUTE,
+                'AttributeType': 'S',
+            },
+            {
+                'AttributeName': TABLE_PRIMARY_RANGE_ATTRIBUTE,
+                'AttributeType': 'S',
+            },
+            {
+                'AttributeName': TABLE_SECONDARY_HASH_ATTRIBUTE,
+                'AttributeType': 'S',
+            },
+        ],
+        TableName=TABLE_NAME,
+        KeySchema=[
+            {'AttributeName': TABLE_PRIMARY_HASH_ATTRIBUTE, 'KeyType': 'HASH'},
+            {
+                'AttributeName': TABLE_PRIMARY_RANGE_ATTRIBUTE,
+                'KeyType': 'RANGE',
+            },
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                'IndexName': TABLE_SECONDARY_HASH_ATTRIBUTE,
+                'KeySchema': [
+                    {
+                        'AttributeName': TABLE_SECONDARY_HASH_ATTRIBUTE,
+                        'KeyType': 'HASH',
+                    },
+                    {
+                        'AttributeName': TABLE_SECONDARY_RANGE_ATTRIBUTE,
+                        'KeyType': 'RANGE',
+                    },
+                ],
+                'Projection': {'ProjectionType': 'ALL'},
+            }
+        ],
+        BillingMode='PAY_PER_REQUEST',
+    )
+
+
+def add_records_to_table():
+    """Add testing data to mocked DynamoDB table"""
+    item = {
+        TABLE_PRIMARY_HASH_ATTRIBUTE: AWS_ACCOUNT_ID,
+        TABLE_INDEX_NAME: TABLE_CATEGORY,
+        TABLE_PRIMARY_RANGE_ATTRIBUTE: '{}+{}'.format(
+            STACK_ID, LOGICAL_RESOURCE_ID
+        ),
+        'last-updated': '2019-02-07T18:40:44.525270Z',
+        'logical-resource-id': LOGICAL_RESOURCE_ID,
+        'region': 'us-west-2',
+        TABLE_ATTRIBUTE_NAME: IAM_ROLE_ARN,
+        'SecurityAuditIAMRoleName': IAM_ROLE_NAME,
+        'stack-id': STACK_ID,
+        'stack-name': 'InfosecClientRoleSecurityAudit',
+    }
+    dynamodb = boto3.resource('dynamodb', region_name=TABLE_REGION)
+    table = dynamodb.Table(TABLE_NAME)
+    table.put_item(Item=item)
+
+
+@mock_dynamodb2
+def test_get_security_audit_role_arns():
+    """Create a table, populate it then fetch IAM Role ARNs"""
+    create_dynamodb_table()
+    add_records_to_table()
+    arns = get_security_audit_role_arns()
+    assert IAM_ROLE_ARN in arns

--- a/cloudformation/tox.ini
+++ b/cloudformation/tox.ini
@@ -3,7 +3,7 @@ envlist = py36, flake8
 skipsdist = true
 
 [testenv:flake8]
-basepython = python
+basepython = python3.6
 deps = flake8
 commands = python -m flake8 functions tests
 


### PR DESCRIPTION
* Run flake8 checks for lambda functions under Python 3 
* Rename pagination argument "credentials" to "client_args"
* Since the argument can be used for more than just credentials, rename it so that it's more clear how it can be used