### PR TITLE
Add compare_group_arn_maps module

### DIFF
--- a/cloudformation/functions/build_group_role_map.py
+++ b/cloudformation/functions/build_group_role_map.py
@@ -66,7 +66,7 @@ def get_federated_groups_for_policy(policy_document: Dict) -> List[str]:
     return []
 
 
-def get_group_role_map(assumed_role_arns: List[str]) -> DictOfLists:
+def build_group_role_map(assumed_role_arns: List[str]) -> DictOfLists:
     """Build map of IAM roles to OIDC groups used in assumption policies.
 
     Given a list of IAM Role ARNs to assume, iterate over those roles,

--- a/cloudformation/functions/compare_group_arn_maps.py
+++ b/cloudformation/functions/compare_group_arn_maps.py
@@ -1,0 +1,181 @@
+import json
+import hashlib
+from typing import Dict, Iterable, Optional
+import boto3
+from .build_group_role_map import flip_map
+
+S3_BUCKET_NAME = 'mozilla-infosec-auth0-rule-assets'
+FILE_PATH = 'access-group-iam-role-map.json'
+
+# via : https://tools.ietf.org/html/rfc4287#section-4.2.7.2
+LINK_HEADER = (
+    '<https://github.com/mozilla-iam/federated-aws-cli/tree/master'
+    '/cloudformation>; rel="via"'
+)
+DictOfLists = Dict[str, list]
+
+
+class MozDefMessageStub():
+    """This is a placeholder stub class which goes away when we switch to
+    libmozdef"""
+    def __init__(self,
+                 summary,
+                 source,
+                 hostname='',
+                 severity='INFO',
+                 category='event',
+                 processid=1,
+                 processname='',
+                 tags=None,
+                 details=None,
+                 timestamp=None,
+                 utctimestamp=None
+                 ):
+        pass
+
+    def send(self, pathway=None, validator=None):
+        return True
+
+
+def emit_event_to_mozdef(
+    new_groups: Iterable[str],
+    deleted_groups: Iterable[str],
+    new_roles: Iterable[str],
+    deleted_roles: Iterable[str],
+    changed_roles: Dict[str, Iterable[str]],
+):
+    """Build and emit an event to MozDef about changes to IAM roles
+
+    :param list new_groups: New OIDC claim groups present in role conditions
+    :param list deleted_groups: OIDC claim groups previously present in role
+                conditions
+    :param list new_roles: New IAM roles which use federated login
+    :param list deleted_roles: IAM roles using federated login which previously
+                               existed
+    :param list changed_roles: IAM roles using federated login that have
+                               changed conditions
+    :return:
+    """
+    accounts_affected = set(
+        map(
+            lambda x: x.split(':')[4],
+            set(new_roles) | set(deleted_roles) | set(changed_roles),
+        )
+    )
+    summary = (
+        'Changes detected with AWS IAM roles used for federated access in AWS '
+        'accounts {}'.format(', '.join(accounts_affected))
+    )
+    source = 'federated-aws'
+    category = 'aws-auth'
+    details = dict()
+    if new_groups:
+        details['new-groups'] = new_groups
+    if deleted_groups:
+        details['deleted-groups'] = deleted_groups
+    if new_roles:
+        details['new-roles'] = new_roles
+    if deleted_roles:
+        details['deleted-roles'] = deleted_roles
+    if changed_roles:
+        details['changed-roles'] = changed_roles
+    message = MozDefMessageStub(
+        summary=summary,
+        source=source,
+        category=category,
+        details=details
+    )
+    message.send()
+    # TODO : Add call to libmozdef once it's published in pypi
+    # to emit an event to MozDef with this data
+
+
+def get_group_role_map(
+    new_group_arn_map: Optional[DictOfLists] = None
+) -> DictOfLists:
+    """Fetch the group role map from S3 unless it doesn't differ from the
+    current one
+
+    :param dict new_group_arn_map: A dictionary mapping groups to lists of
+                                   roles
+    :return: Parsed content of the group role map file (a dict of lists)
+    """
+    client = boto3.client('s3')
+    kwargs = {'Bucket': S3_BUCKET_NAME, 'Key': FILE_PATH}
+    if new_group_arn_map is not None:
+        new_map_serialized = serialize_group_role_map(new_group_arn_map)
+        kwargs['IfNoneMatch'] = hashlib.md5(new_map_serialized).hexdigest()
+    try:
+        response = client.get_object(**kwargs)
+    except client.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == '304':
+            return new_group_arn_map
+        if e.response['Error']['Code'] == 'NoSuchKey':
+            return dict()
+        else:
+            raise
+    return json.load(response['Body'])
+
+
+def serialize_group_role_map(group_role_map: DictOfLists) -> str:
+    """Serialize a dictionary of lists in a consistent hashable format
+
+    :param dict group_role_map: A dictionary mapping groups to lists of roles
+    :return: A serialized JSON string
+    """
+    return json.dumps(group_role_map, sort_keys=True, indent=4).encode('utf-8')
+
+
+def store_group_arn_map(new_group_arn_map: DictOfLists) -> bool:
+    """Compare the new group ARN map with the existing map stored in S3
+
+    Store the new map and emit an event to MozDef if they differ. Return True
+    if there was a change and False if not.
+
+    :param dict new_group_arn_map: A dictionary mapping groups to lists of
+                                   roles
+    :return: True if the new map differs from the one stored, otherwise False
+    """
+    existing_group_arn_map = get_group_role_map(new_group_arn_map)
+    if existing_group_arn_map is False:
+        # The new_map is the same as the existing_map
+        return False
+    new_groups = set(new_group_arn_map) - set(existing_group_arn_map)
+    deleted_groups = set(existing_group_arn_map) - set(
+        new_group_arn_map.keys()
+    )
+    new_arn_group_map = flip_map(new_group_arn_map)
+    existing_arn_group_map = flip_map(existing_group_arn_map)
+    new_roles = set(new_arn_group_map) - set(existing_arn_group_map)
+    deleted_roles = set(existing_arn_group_map) - set(new_arn_group_map)
+    changed_roles = {}
+    for role, groups in new_arn_group_map.items():
+        if role in existing_arn_group_map:
+            if len(set(groups) ^ set(existing_arn_group_map[role])) > 0:
+                changed_roles[role] = {
+                    'new_groups': set(groups),
+                    'old_groups': set(existing_arn_group_map[role]),
+                }
+    if (
+        new_groups
+        or deleted_groups
+        or new_roles
+        or deleted_roles
+        or changed_roles
+    ):
+        emit_event_to_mozdef(
+            new_groups, deleted_groups, new_roles, deleted_roles, changed_roles
+        )
+        new_map_serialized = serialize_group_role_map(new_group_arn_map)
+        client = boto3.client('s3')
+        # Link : https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link
+        client.put_object(
+            Body=new_map_serialized,
+            Bucket=S3_BUCKET_NAME,
+            ContentType='application/json',
+            Key=FILE_PATH,
+            Metadata={'Link': LINK_HEADER},
+        )
+        return True
+    else:
+        return False

--- a/cloudformation/functions/get_group_role_map.py
+++ b/cloudformation/functions/get_group_role_map.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 import collections
 import boto3
 
@@ -10,8 +10,8 @@ def get_paginated_results(
     product: str,
     action: str,
     key: str,
-    client_args: SimpleDict = None,
-    action_args: SimpleDict = None,
+    client_args: Optional[SimpleDict] = None,
+    action_args: Optional[SimpleDict] = None,
 ) -> list:
     """Paginate through AWS API responses, combining them into a list
 

--- a/cloudformation/functions/get_group_role_map.py
+++ b/cloudformation/functions/get_group_role_map.py
@@ -37,8 +37,8 @@ def get_paginated_results(
     ]
 
 
-def flip_map(arn_group_map: DictOfLists) -> DictOfLists:
-    """Flip the map of ARN to group list to group to ARN list
+def flip_map(dict_of_lists: DictOfLists) -> DictOfLists:
+    """Flip a map of keys to lists to a map of list elements to lists of keys
 
     Flips an input like
 
@@ -51,12 +51,12 @@ def flip_map(arn_group_map: DictOfLists) -> DictOfLists:
      'team_bar': ['arn:aws:iam::123...', 'arn:aws:iam::456...'],
      'team_baz': ['arn:aws:iam::456...']}
 
-    :param dict arn_group_map: ARN to group list map
-    :return: Group to ARN list map
+    :param dict dict_of_lists: dictionary of lists
+    :return: The flipped map
     """
     group_arn_map = collections.defaultdict(list)
-    for arn in arn_group_map:
-        for group in arn_group_map[arn]:
+    for arn in dict_of_lists:
+        for group in dict_of_lists[arn]:
             group_arn_map[group].append(arn)
     return group_arn_map
 

--- a/cloudformation/functions/get_security_audit_role_arns.py
+++ b/cloudformation/functions/get_security_audit_role_arns.py
@@ -1,5 +1,5 @@
 from typing import List
-from .get_group_role_map import get_paginated_results
+from .build_group_role_map import get_paginated_results
 
 # AWS Account : infosec-prod
 TABLE_CATEGORY = 'AWS Security Auditing Service'

--- a/cloudformation/functions/tests/test_build_group_role_map.py
+++ b/cloudformation/functions/tests/test_build_group_role_map.py
@@ -1,6 +1,6 @@
 import boto3
 from moto import mock_iam, mock_sts
-from ..get_group_role_map import get_group_role_map
+from ..build_group_role_map import build_group_role_map
 
 
 @mock_iam
@@ -52,7 +52,7 @@ def test_get_role_group_map():
         AssumeRolePolicyDocument=assume_role_policy_document_with_conditions,
         Description='Test role with federated conditions',
     )
-    groups = get_group_role_map([role_to_assume_arn])
+    groups = build_group_role_map([role_to_assume_arn])
 
     assert len(groups) == 0
 

--- a/cloudformation/functions/tests/test_compare_group_arn_maps.py
+++ b/cloudformation/functions/tests/test_compare_group_arn_maps.py
@@ -1,0 +1,101 @@
+from unittest.mock import patch
+from ..compare_group_arn_maps import (
+    store_group_arn_map,
+    get_group_role_map,
+    S3_BUCKET_NAME,
+)
+from .. import compare_group_arn_maps
+import boto3
+from moto import mock_s3
+
+# https://stackoverflow.com/a/23844656/168874
+@mock_s3
+@patch.object(compare_group_arn_maps, 'emit_event_to_mozdef')
+def test_store_group_arn_map(emit_event_to_mozdef):
+    client = boto3.client('s3')
+    client.create_bucket(Bucket=S3_BUCKET_NAME)
+    beginning_group_arn_map = get_group_role_map()
+    assert len(beginning_group_arn_map) == 0
+
+    first_group_arn_map_to_send = {
+        'team_foo': [
+            'arn:aws:iam::123456789012:role/BarRole',
+            'arn:aws:iam::123456789012:role/BazRole',
+        ],
+        'team_qux': [
+            'arn:aws:iam::123456789012:role/BarRole',
+            'arn:aws:iam::123456789012:role/XyzzyRole',
+        ],
+    }
+    new_map_updated = store_group_arn_map(first_group_arn_map_to_send)
+    assert new_map_updated is True
+    emit_event_to_mozdef.assert_called_with(
+        set(first_group_arn_map_to_send.keys()),
+        set(),
+        set(
+            first_group_arn_map_to_send['team_foo']
+            + first_group_arn_map_to_send['team_qux']
+        ),
+        set(),
+        dict(),
+    )
+
+    first_group_arn_map_fetched = get_group_role_map()
+    assert 'team_foo' in first_group_arn_map_fetched
+    assert (
+        'arn:aws:iam::123456789012:role/BarRole'
+        in first_group_arn_map_fetched.get('team_foo', [])
+    )
+
+    first_group_arn_map_fetched_again = get_group_role_map(
+        first_group_arn_map_fetched
+    )
+    assert 'team_foo' in first_group_arn_map_fetched_again
+    assert (
+        'arn:aws:iam::123456789012:role/BarRole'
+        in first_group_arn_map_fetched_again.get('team_foo', [])
+    )
+    # TODO : Somehow test that this last call to get_group_role_map triggered
+    # a 304
+
+    same_map_updated = store_group_arn_map(first_group_arn_map_to_send)
+    assert same_map_updated is False
+    first_group_arn_map_fetched_a_third_time = get_group_role_map(
+        first_group_arn_map_fetched_again
+    )
+    assert 'team_foo' in first_group_arn_map_fetched_a_third_time
+    assert (
+        'arn:aws:iam::123456789012:role/BarRole'
+        in first_group_arn_map_fetched_a_third_time.get('team_foo', [])
+    )
+
+    second_group_arn_map_to_send = {
+        'team_foo': ['arn:aws:iam::123456789012:role/BazRole'],
+        'team_qux': [
+            'arn:aws:iam::123456789012:role/BarRole',
+            'arn:aws:iam::123456789012:role/XyzzyRole',
+        ],
+    }
+    changed_map_updated = store_group_arn_map(second_group_arn_map_to_send)
+    assert changed_map_updated is True
+    emit_event_to_mozdef.assert_called_with(
+        set(),
+        set(),
+        set(),
+        set(),
+        {
+            'arn:aws:iam::123456789012:role/BarRole': {
+                'new_groups': {'team_qux'},
+                'old_groups': {'team_qux', 'team_foo'},
+            }
+        }
+    )
+
+    second_group_arn_map_fetched = get_group_role_map(
+        second_group_arn_map_to_send
+    )
+    assert 'team_foo' in second_group_arn_map_fetched
+    assert (
+        'arn:aws:iam::123456789012:role/BarRole'
+        not in second_group_arn_map_fetched.get('team_foo', [])
+    )


### PR DESCRIPTION
This fetches, stores and compares the group ARN map in S3

Also 
* Clarify optional arguments with type hints 
* Make flip_map generic to work with flipping maps either direction 
* Rename get_group_role_map to build_group_role_map 