### PR TITLE
Accommodate security IAM roles which have been deleted

### DIFF
--- a/cloudformation/Makefile
+++ b/cloudformation/Makefile
@@ -1,5 +1,5 @@
 STACK_NAME		:= GroupRoleMapBuilder
-PROD_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME	:= public.us-west-2.security.mozilla.org
+PROD_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME	:= public.us-west-2.infosec.mozilla.org
 DEV_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME	:= public.us-west-2.security.allizom.org
 LAMBDA_CODE_STORAGE_S3_PREFIX		:= group-role-map-builder
 PROD_ACCOUNT_ID	:= 371522382791

--- a/cloudformation/Makefile
+++ b/cloudformation/Makefile
@@ -4,6 +4,7 @@ DEV_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME	:= public.us-west-2.security.allizom.org
 LAMBDA_CODE_STORAGE_S3_PREFIX		:= group-role-map-builder
 PROD_ACCOUNT_ID	:= 371522382791
 DEV_ACCOUNT_ID	:= 656532927350
+PROD_GROUP_ROLE_MAP_S3_BUCKET_NAME	:= mozilla-infosec-auth0-rule-assets
 DEV_GROUP_ROLE_MAP_S3_BUCKET_NAME	:= mozilla-infosec-auth0-dev-rule-assets
 
 LAMBDA_CODE_STORAGE_S3_PREFIX_ARG	:= $(if $(LAMBDA_CODE_STORAGE_S3_PREFIX),--s3-prefix $(LAMBDA_CODE_STORAGE_S3_PREFIX),"")
@@ -18,7 +19,10 @@ deploy:
 		--s3-bucket $(PROD_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME) \
 		$(LAMBDA_CODE_STORAGE_S3_PREFIX_ARG) \
 		--output-template-file $(TMPFILE)
-	aws cloudformation deploy --template-file $(TMPFILE) --stack-name $(STACK_NAME) --capabilities CAPABILITY_IAM
+	aws cloudformation deploy --template-file $(TMPFILE) --stack-name $(STACK_NAME) \
+	 	--capabilities CAPABILITY_IAM \
+		--parameter-overrides \
+			S3BucketName=$(PROD_GROUP_ROLE_MAP_S3_BUCKET_NAME)
 	rm $(TMPFILE)
 
 .PHONE: deploy-dev

--- a/cloudformation/functions/group_role_map_builder.py
+++ b/cloudformation/functions/group_role_map_builder.py
@@ -18,9 +18,7 @@ TABLE_ATTRIBUTE_NAME = os.getenv(
 )
 TABLE_NAME = os.getenv('TABLE_NAME', 'cloudformation-stack-emissions')
 TABLE_REGION = os.getenv('TABLE_REGION', 'us-west-2')
-S3_BUCKET_NAME = os.getenv(
-    'S3_BUCKET_NAME', 'mozilla-infosec-auth0-rule-assets'
-)
+S3_BUCKET_NAME = os.getenv('S3_BUCKET_NAME')
 S3_FILE_PATH = os.getenv('S3_FILE_PATH', 'access-group-iam-role-map.json')
 VALID_AMRS = os.getenv(
     'VALID_AMRS', 'auth-dev.mozilla.auth0.com/:amr,auth.mozilla.auth0.com/:amr'
@@ -311,6 +309,7 @@ def store_group_arn_map(new_group_arn_map: DictOfLists) -> bool:
                                    roles
     :return: True if the new map differs from the one stored, otherwise False
     """
+    assert S3_BUCKET_NAME is not None
     existing_group_arn_map = get_group_role_map(new_group_arn_map)
     if existing_group_arn_map is False:
         # The new_map is the same as the existing_map

--- a/cloudformation/functions/group_role_map_builder.py
+++ b/cloudformation/functions/group_role_map_builder.py
@@ -454,6 +454,6 @@ def lambda_handler(event, context):
     )
     map_changed = store_group_arn_map(group_role_map)
     if map_changed:
-        logger.info('Group role map in S3 updated')
+        logger.info('Group role map in S3 updated : {}'.format(group_role_map))
 
     return group_role_map

--- a/cloudformation/functions/group_role_map_builder.py
+++ b/cloudformation/functions/group_role_map_builder.py
@@ -9,6 +9,9 @@ import boto3
 
 logger = logging.getLogger(__name__)
 logging.getLogger().setLevel(logging.INFO)
+logging.getLogger('boto3').propagate = False
+logging.getLogger('botocore').propagate = False
+logging.getLogger('urllib3').propagate = False
 
 # AWS Account : infosec-prod
 TABLE_CATEGORY = os.getenv('TABLE_CATEGORY', 'AWS Security Auditing Service')
@@ -449,9 +452,6 @@ def lambda_handler(event, context):
         )
     )
     group_role_map = build_group_role_map(security_audit_role_arns)
-    logger.debug(
-        'Role map built : {}'.format(serialize_group_role_map(group_role_map))
-    )
     map_changed = store_group_arn_map(group_role_map)
     if map_changed:
         logger.info('Group role map in S3 updated : {}'.format(group_role_map))

--- a/cloudformation/group_role_map_builder.yaml
+++ b/cloudformation/group_role_map_builder.yaml
@@ -115,3 +115,11 @@ Resources:
       Action: "lambda:InvokeFunction"
       Principal: "events.amazonaws.com"
       SourceArn: !GetAtt GroupRoleMapBuilderScheduledRule.Arn
+  GroupRoleMapBuilderFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      # Let's hope that the Lambda function doesn't execute before this LogGroup
+      # resource is created, creating the LogGroup with no expiration and
+      # preventing this resource from creating
+      LogGroupName: !Join [ '/', ['/aws/lambda', !Ref 'GroupRoleMapBuilderFunction' ] ]
+      RetentionInDays: 14

--- a/cloudformation/group_role_map_builder.yaml
+++ b/cloudformation/group_role_map_builder.yaml
@@ -99,7 +99,7 @@ Resources:
           Value: !Ref AWS::StackName
         - Key: source
           Value: https://github.com/mozilla-iam/federated-aws-cli/tree/master/cloudformation
-      Timeout: 20
+      Timeout: 900
   GroupRoleMapBuilderScheduledRule:
     Type: AWS::Events::Rule
     Properties:

--- a/cloudformation/group_role_map_builder.yaml
+++ b/cloudformation/group_role_map_builder.yaml
@@ -12,7 +12,6 @@ Parameters:
   S3BucketName:
     Type: String
     Description: The S3 bucket to store the group role map file in
-    Default: mozilla-infosec-auth0-rule-assets
   S3FilePath:
     Type: String
     Description: The path to the group role map file

--- a/cloudformation/group_role_map_builder.yaml
+++ b/cloudformation/group_role_map_builder.yaml
@@ -97,6 +97,8 @@ Resources:
           Value: group-role-map-builder
         - Key: stack
           Value: !Ref AWS::StackName
+        - Key: source
+          Value: https://github.com/mozilla-iam/federated-aws-cli/tree/master/cloudformation
       Timeout: 20
   GroupRoleMapBuilderScheduledRule:
     Type: AWS::Events::Rule

--- a/cloudformation/group_role_map_builder.yaml
+++ b/cloudformation/group_role_map_builder.yaml
@@ -106,7 +106,7 @@ Resources:
       State: "ENABLED"
       Targets:
         - Arn: !GetAtt GroupRoleMapBuilderFunction.Arn
-          Id: "InvitationManager"
+          Id: "GroupRoleMapBuilder"
   PermissionForEventsToInvokeLambda:
     Type: AWS::Lambda::Permission
     Properties:

--- a/cloudformation/tox.ini
+++ b/cloudformation/tox.ini
@@ -13,6 +13,7 @@ commands = python -m flake8 functions tests
 setenv =
     PYTHONPATH = {toxinidir}
 	BOTO_CONFIG = /dev/null
+    S3_BUCKET_NAME=test-bucket
 deps =
     moto
     pytest

--- a/cloudformation/tox.ini
+++ b/cloudformation/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = py36, flake8
+envlist = py37, flake8
 skipsdist = true
 
 [testenv:flake8]
-basepython = python3.6
+basepython = python3.7
 deps = flake8
 commands = python -m flake8 functions tests
 


### PR DESCRIPTION
* Switch tox to py37 to match Lambda interpreter 
* Fix default s3 bucket name in Makefile 
* Remove default S3 bucket name
  * Since S3 bucket names are a global namespace, there's little value in having a default
* Log new group role map if it changes 
* Set LogGroup retention time 
* Fix copy paste name mistake 
* Add Lambda function tag pointing to source code location 
* Clarify logging 
* Increase timeout for group role map builder 
* Accommodate security IAM roles which have been deleted
  * In the case where an AWS account is closed and the CloudFormation stacks
within are not torn down, the cross account stack emissions DB will contain
IAM role ARNs which no longer exist. This logs that they don't work and skips them.