### PR TITLE
 Add custom domain names, alias map endpoint

### DIFF
--- a/cloudformation/Makefile
+++ b/cloudformation/Makefile
@@ -1,13 +1,20 @@
 GROUP_ROLE_MAP_BUILDER_STACK_NAME	:= GroupRoleMapBuilder
 IDTOKEN_FOR_ROLES_STACK_NAME		:= IdtokenForRoles
-PROD_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME	:= public.us-west-2.infosec.mozilla.org
-DEV_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME	:= public.us-west-2.security.allizom.org
 GROUP_ROLE_MAP_BUILDER_CODE_STORAGE_S3_PREFIX	:= group-role-map-builder
 IDTOKEN_FOR_ROLES_CODE_STORAGE_S3_PREFIX		:= idtoken-for-roles
+
+PROD_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME	:= public.us-west-2.infosec.mozilla.org
+DEV_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME	:= public.us-west-2.security.allizom.org
 PROD_ACCOUNT_ID	:= 371522382791
 DEV_ACCOUNT_ID	:= 656532927350
 PROD_S3_BUCKET_NAME	:= mozilla-infosec-auth0-rule-assets
 DEV_S3_BUCKET_NAME	:= mozilla-infosec-auth0-dev-rule-assets
+PROD_DOMAIN_NAME	:= roles-and-aliases.security.mozilla.org
+DEV_DOMAIN_NAME		:= roles-and-aliases.security.allizom.org
+PROD_DOMAIN_ZONE	:= security.mozilla.org.
+DEV_DOMAIN_ZONE		:= security.allizom.org.
+PROD_CERT_ARN		:= arn:aws:acm:us-west-2:371522382791:certificate/88c3077f-9b6a-490e-9d7c-67bee0f72eb4
+DEV_CERT_ARN		:= arn:aws:acm:us-west-2:656532927350:certificate/46428d8b-7b26-4ad0-84d1-cd2d386e7a43
 
 .PHONE: deploy-group-role-map-builder
 deploy-group-role-map-builder:
@@ -35,9 +42,21 @@ deploy-idtoken-for-roles-dev:
 		 $(DEV_S3_BUCKET_NAME) \
 		 $(IDTOKEN_FOR_ROLES_STACK_NAME) \
 		 $(IDTOKEN_FOR_ROLES_CODE_STORAGE_S3_PREFIX) \
-		 ApiEndpointUrl
+		 "CustomDomainName=$(DEV_DOMAIN_NAME) DomainNameZone=$(DEV_DOMAIN_ZONE) CertificateArn=$(DEV_CERT_ARN)" \
+		 AliasesEndpointUrl
 
-.PHONE: test-idtoken-for-roles-dev
-test-idtoken-for-roles-dev:
-	URL=`aws cloudformation describe-stacks --stack-name $(IDTOKEN_FOR_ROLES_STACK_NAME) --query "Stacks[0].Outputs[?OutputKey=='ApiEndpointUrl'].OutputValue" --output text` && \
-	curl -d '{"foo":"bar", "baz":"buz"}' -H "Content-Type: application/json" -X POST $$URL
+.PHONE: deploy-idtoken-for-roles
+deploy-idtoken-for-roles:
+	./deploy.sh \
+		 $(PROD_ACCOUNT_ID) \
+		 idtoken_for_roles/idtoken_for_roles.yaml \
+		 $(PROD_S3_BUCKET_NAME) \
+		 $(IDTOKEN_FOR_ROLES_STACK_NAME) \
+		 $(IDTOKEN_FOR_ROLES_CODE_STORAGE_S3_PREFIX) \
+		 "CustomDomainName=$(PROD_DOMAIN_NAME) DomainNameZone=$(PROD_DOMAIN_ZONE) CertificateArn=$(PROD_CERT_ARN)" \
+		 AliasesEndpointUrl
+
+.PHONE: test-idtoken-for-roles
+test-idtoken-for-roles:
+	URL=`aws cloudformation describe-stacks --stack-name $(IDTOKEN_FOR_ROLES_STACK_NAME) --query "Stacks[0].Outputs[?OutputKey=='AliasesEndpointUrl'].OutputValue" --output text` && \
+	curl $$URL

--- a/cloudformation/group_role_map_builder/group_role_map_builder.yaml
+++ b/cloudformation/group_role_map_builder/group_role_map_builder.yaml
@@ -2,6 +2,30 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: Lambda function which builds the OIDC claim group to role map file and uploads it to S3. Function is triggered hourly
 Metadata:
   Source: https://github.com/mozilla-iam/federated-aws-cli/blob/master/cloudformation/group_role_map_builder/group_role_map_builder.yaml
+  'AWS::CloudFormation::Interface':
+    ParameterGroups:
+    - Label:
+        default: Stack Emission Table
+      Parameters:
+      - StackEmissionDynamoDBTableName
+      - StackEmissionDynamoDBTableRegion
+    - Label:
+        default: S3
+      Parameters:
+      - S3BucketName
+      - GroupRoleMapS3FilePath
+      - AccountAliasesS3FilePath
+    ParameterLabels:
+      StackEmissionDynamoDBTableName:
+        default: Stack Emission DynamoDB Table Name
+      StackEmissionDynamoDBTableRegion:
+        default: Stack Emission DynamoDB Region
+      S3BucketName:
+        default: S3 Bucket Name
+      GroupRoleMapS3FilePath:
+        default: Group Role Map S3 File Path
+      AccountAliasesS3FilePath:
+        default: AWS Account Alias Map S3 File Path
 Parameters:
   StackEmissionDynamoDBTableName:
     Type: String

--- a/cloudformation/group_role_map_builder/group_role_map_builder.yaml
+++ b/cloudformation/group_role_map_builder/group_role_map_builder.yaml
@@ -1,5 +1,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Lambda function which builds the OIDC claim group to role map file and uploads it to S3. Function is triggered hourly
+Metadata:
+  Source: https://github.com/mozilla-iam/federated-aws-cli/blob/master/cloudformation/group_role_map_builder/group_role_map_builder.yaml
 Parameters:
   StackEmissionDynamoDBTableName:
     Type: String

--- a/cloudformation/idtoken_for_roles/idtoken_for_roles.yaml
+++ b/cloudformation/idtoken_for_roles/idtoken_for_roles.yaml
@@ -2,6 +2,48 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: Lambda function and API which accepts an OIDC ID Token and returns a list of IAM Roles
 Metadata:
   Source: https://github.com/mozilla-iam/federated-aws-cli/blob/master/cloudformation/idtoken_for_roles/idtoken_for_roles.yaml
+  'AWS::CloudFormation::Interface':
+    ParameterGroups:
+    - Label:
+        default: S3
+      Parameters:
+      - S3BucketName
+      - GroupRoleMapS3FilePath
+      - AccountAliasesS3FilePath
+    - Label:
+        default: Authentication
+      Parameters:
+      - AllowedIssuer
+      - AllowedAudience
+    - Label:
+        default: API
+      Parameters:
+      - RolesPathPrefix
+      - AliasesPathPrefix
+      - CustomDomainName
+      - DomainNameZone
+      - CertificateArn
+    ParameterLabels:
+      S3BucketName:
+        default: S3 Bucket Name
+      GroupRoleMapS3FilePath:
+        default: Group Role Map S3 File Path
+      AccountAliasesS3FilePath:
+        default: AWS Account Alias Map S3 File Path
+      AllowedIssuer:
+        default: Allowed OIDC Issuer
+      AllowedAudience:
+        default: Allowed OIDC Audience
+      RolesPathPrefix:
+        default: API Path Prefix for the Group Role Map endpoint
+      AliasesPathPrefix:
+        default: API Path Prefix for the AWS Account Alias Map endpoint
+      CustomDomainName:
+        default: Custom DNS Domain Name
+      DomainNameZone:
+        default: DNS Zone containing the Custom DNS Domain Name
+      CertificateArn:
+        default: AWS ACM Certificate ARN for the Custom DNS Domain Name
 Parameters:
   S3BucketName:
     Type: String

--- a/cloudformation/idtoken_for_roles/idtoken_for_roles.yaml
+++ b/cloudformation/idtoken_for_roles/idtoken_for_roles.yaml
@@ -1,5 +1,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Lambda function and API which accepts an OIDC ID Token and returns a list of IAM Roles
+Metadata:
+  Source: https://github.com/mozilla-iam/federated-aws-cli/blob/master/cloudformation/idtoken_for_roles/idtoken_for_roles.yaml
 Parameters:
   S3BucketName:
     Type: String

--- a/cloudformation/idtoken_for_roles/idtoken_for_roles.yaml
+++ b/cloudformation/idtoken_for_roles/idtoken_for_roles.yaml
@@ -22,10 +22,34 @@ Parameters:
     Type: String
     Description: OIDC Audience. For Mozilla this is the Auth0 Client ID
     Default: xRFzU2bj7Lrbo3875aXwyxIArdkq1AOT
-  ApiPathPrefix:
+  RolesPathPrefix:
     Type: String
-    Description: The URL path prefix for the new API
+    Description: The URL path prefix to POST ID tokens to and get back roles
     Default: roles
+  AliasesPathPrefix:
+    Type: String
+    Description: The URL path prefix to GET account aliases from
+    Default: account-aliases
+  CustomDomainName:
+    Type: String
+    Description: The custom domain name to use for the API
+    Default: ''
+  DomainNameZone:
+    Type: String
+    Description: The Route53 DNS zone containing the custom domain name
+    Default: ''
+  CertificateArn:
+    Type: String
+    Description: The ARN of the AWS ACM Certificate for your custom domain name
+    Default: ''
+Conditions:
+  UseCustomDomainName: !Not [ !Equals [ !Ref 'CustomDomainName', '' ] ]
+Rules:
+  DomainNameAndCertificateArnProvided:
+    RuleCondition: !Or [ !Not [ !Equals [ !Ref 'CustomDomainName', '' ] ], !Not [ !Equals [ !Ref 'DomainNameZone', '' ] ], !Not [ !Equals [ !Ref 'CertificateArn', '' ] ] ]
+    Assertions:
+      - Assert: !And [ !Not [ !Equals [ !Ref 'CustomDomainName', '' ] ], !Not [ !Equals [ !Ref 'DomainNameZone', '' ] ], !Not [ !Equals [ !Ref 'CertificateArn', '' ] ] ]
+        AssertDescription: If you set a CustomDomainName, DomainNameZone or CertificateArn you must provide all values
 Resources:
   IdtokenForRolesFunctionRole:
     Type: AWS::IAM::Role
@@ -95,60 +119,57 @@ Resources:
       # preventing this resource from creating
       LogGroupName: !Join [ '/', ['/aws/lambda', !Ref 'IdtokenForRolesFunction' ] ]
       RetentionInDays: 14
+  IdtokenForRolesDomainName:
+    Type: AWS::ApiGateway::DomainName
+    Condition: UseCustomDomainName
+    Properties:
+      RegionalCertificateArn: !Ref CertificateArn
+      DomainName: !Ref CustomDomainName
+      EndpointConfiguration:
+        Types:
+          - REGIONAL
+  IdtokenForRolesRoute53RecordSet:
+    Type: AWS::Route53::RecordSet
+    Condition: UseCustomDomainName
+    Properties:
+      AliasTarget:
+        DNSName: !GetAtt IdtokenForRolesDomainName.RegionalDomainName
+        HostedZoneId: !GetAtt IdtokenForRolesDomainName.RegionalHostedZoneId
+      Comment: Bind the custom domain name to the IdtokenForRoles API Gateway
+      HostedZoneName: !Ref DomainNameZone
+      Name: !Ref CustomDomainName
+      Type: A
   IdtokenForRolesApi:
     Type: AWS::ApiGateway::RestApi
     Properties:
       Name: IdTokenForRoles
       Description: Exchange an ID Token for a list of IAM Roles
       FailOnWarnings: true
+      EndpointConfiguration:
+        Types:
+          - REGIONAL
+  IdtokenForRolesBasePathMapping:
+    Type: AWS::ApiGateway::BasePathMapping
+    Condition: UseCustomDomainName
+    Properties:
+      DomainName: !Ref IdtokenForRolesDomainName
+      RestApiId: !Ref IdtokenForRolesApi
+      Stage: !Ref IdtokenForRolesApiStage
   IdtokenForRolesLambdaPermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:invokeFunction
       FunctionName: !GetAtt IdtokenForRolesFunction.Arn
       Principal: apigateway.amazonaws.com
-      SourceArn: !Join [ '', [ 'arn:aws:execute-api:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref 'IdtokenForRolesApi', '/*' ] ]
-  IdtokenForRolesApiGatewayRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - apigateway.amazonaws.com
-            Action:
-              - sts:AssumeRole
-      Policies:
-        - PolicyName: ApiGatewayLogsPolicy
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - logs:CreateLogGroup
-                  - logs:CreateLogStream
-                  - logs:DescribeLogGroups
-                  - logs:DescribeLogStreams
-                  - logs:PutLogEvents
-                  - logs:GetLogEvents
-                  - logs:FilterLogEvents
-                Resource: '*'
-  IdtokenForRolesApiGatewayAccount:
-    Type: AWS::ApiGateway::Account
-    Properties:
-      CloudWatchRoleArn: !GetAtt IdtokenForRolesApiGatewayRole.Arn
+      SourceArn: !Join [ '', [ 'arn:aws:execute-api:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref 'IdtokenForRolesApi', '/*/*' ] ]
   IdtokenForRolesApiStage:
-    DependsOn:
-      - IdtokenForRolesApiGatewayAccount
     Type: AWS::ApiGateway::Stage
     Properties:
       DeploymentId: !Ref IdtokenForRolesApiDeployment
       MethodSettings:
         - DataTraceEnabled: true
           HttpMethod: '*'
-          LoggingLevel: INFO
+          # LoggingLevel: INFO
           ResourcePath: /*
       RestApiId: !Ref IdtokenForRolesApi
       Tags:
@@ -180,7 +201,13 @@ Resources:
     Properties:
       RestApiId: !Ref IdtokenForRolesApi
       ParentId: !GetAtt IdtokenForRolesApi.RootResourceId
-      PathPart: !Ref ApiPathPrefix
+      PathPart: !Ref RolesPathPrefix
+  AliasesResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref IdtokenForRolesApi
+      ParentId: !GetAtt IdtokenForRolesApi.RootResourceId
+      PathPart: !Ref AliasesPathPrefix
   IdtokenForRoleRolesRequest:
     DependsOn: IdtokenForRolesLambdaPermission
     Type: AWS::ApiGateway::Method
@@ -202,7 +229,34 @@ Resources:
       MethodResponses:
         - StatusCode: '200'
           # TODO Add a 403 mapping for when the idtoken is invalid
+  AliasesRequest:
+    DependsOn: IdtokenForRolesLambdaPermission
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: NONE
+      HttpMethod: GET
+      Integration:
+        Type: AWS
+        IntegrationHttpMethod: POST
+        Uri: !Join [ '', [ 'arn:aws:apigateway:', !Ref 'AWS::Region', ':lambda:path/2015-03-31/functions/', !GetAtt 'IdtokenForRolesFunction.Arn', '/invocations' ] ]
+        IntegrationResponses:
+          - StatusCode: '200'
+      ResourceId: !Ref AliasesResource
+      RestApiId: !Ref IdtokenForRolesApi
+      MethodResponses:
+        - StatusCode: '200'
 Outputs:
-  ApiEndpointUrl:
-    Description: The URL of the API Endpoint
-    Value: !Join [ '', [ 'https://', !Ref 'IdtokenForRolesApi', '.execute-api.', !Ref 'AWS::Region', '.amazonaws.com/', !Ref 'IdtokenForRolesApiStage', '/', !Ref 'ApiPathPrefix' ] ]
+  RolesEndpointUrl:
+    Description: The URL of the token for roles API Endpoint
+    Value:
+      Fn::If:
+        - UseCustomDomainName
+        - !Join [ '', [ 'https://', !Ref 'CustomDomainName', '/', !Ref 'RolesPathPrefix'] ]
+        - !Join [ '', [ 'https://', !Ref 'IdtokenForRolesApi', '.execute-api.', !Ref 'AWS::Region', '.amazonaws.com/', !Ref 'IdtokenForRolesApiStage', '/', !Ref 'RolesPathPrefix' ] ]
+  AliasesEndpointUrl:
+    Description: The URL of the token for aliases API Endpoint
+    Value:
+      Fn::If:
+        - UseCustomDomainName
+        - !Join [ '', [ 'https://', !Ref 'CustomDomainName', '/', !Ref 'AliasesPathPrefix'] ]
+        - !Join [ '', [ 'https://', !Ref 'IdtokenForRolesApi', '.execute-api.', !Ref 'AWS::Region', '.amazonaws.com/', !Ref 'IdtokenForRolesApiStage', '/', !Ref 'AliasesPathPrefix' ] ]


### PR DESCRIPTION
* Add support for custom domain names
* Add API endpoint that returns AWS account ID alias map
* Removed code that enables API Gateway logging to CloudWatch as that should be managed by an account-wide template, not this specific service