### PR TITLE
Fix bug with valid StringEquals conditions

### DIFF
--- a/cloudformation/group_role_map_builder/tests/policies/one_group_stringequals.json
+++ b/cloudformation/group_role_map_builder/tests/policies/one_group_stringequals.json
@@ -1,0 +1,21 @@
+{
+  "Version": "2012-10-17",
+  "Returns": ["one_group"],
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::656532927350:oidc-provider/auth-dev.mozilla.auth0.com/"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "auth-dev.mozilla.auth0.com/:aud": "xRFzU2bj7Lrbo3875aXwyxIArdkq1AOT"
+        },
+        "ForAnyValue:StringEquals": {
+          "auth-dev.mozilla.auth0.com/:amr": "one_group"
+        }
+      }
+    }
+  ]
+}

--- a/cloudformation/tox.ini
+++ b/cloudformation/tox.ini
@@ -5,7 +5,7 @@ skipsdist = true
 [testenv:flake8]
 basepython = python3.7
 deps = flake8
-commands = python -m flake8 functions tests
+commands = python -m flake8
 
 [testenv]
 # BOTO_CONFIG


### PR DESCRIPTION
* fix flake8 tox check so flake8 checks code
* resolve flake8 warnings
* add debug and error logging

Cause of the bug was that `any([[False],[False]])` is `True` not `False`