### PR TITLE
Allow for passing in prod and dev specific config values

### DIFF
--- a/cloudformation/Makefile
+++ b/cloudformation/Makefile
@@ -5,8 +5,8 @@ IDTOKEN_FOR_ROLES_CODE_STORAGE_S3_PREFIX		:= idtoken-for-roles
 
 PROD_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME	:= public.us-west-2.infosec.mozilla.org
 DEV_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME	:= public.us-west-2.security.allizom.org
-PROD_ACCOUNT_ID	:= 371522382791
-DEV_ACCOUNT_ID	:= 656532927350
+PROD_ACCOUNT_ID		:= 371522382791
+DEV_ACCOUNT_ID		:= 656532927350
 PROD_S3_BUCKET_NAME	:= mozilla-infosec-auth0-rule-assets
 DEV_S3_BUCKET_NAME	:= mozilla-infosec-auth0-dev-rule-assets
 PROD_DOMAIN_NAME	:= roles-and-aliases.security.mozilla.org
@@ -15,6 +15,14 @@ PROD_DOMAIN_ZONE	:= security.mozilla.org.
 DEV_DOMAIN_ZONE		:= security.allizom.org.
 PROD_CERT_ARN		:= arn:aws:acm:us-west-2:371522382791:certificate/88c3077f-9b6a-490e-9d7c-67bee0f72eb4
 DEV_CERT_ARN		:= arn:aws:acm:us-west-2:656532927350:certificate/46428d8b-7b26-4ad0-84d1-cd2d386e7a43
+PROD_CLIENT_ID		:= N7lULzWtfVUDGymwDs0yDEq6ZcwmFazj
+DEV_CLIENT_ID		:= xRFzU2bj7Lrbo3875aXwyxIArdkq1AOT
+PROD_ISSUER			:= https://auth.mozilla.auth0.com/
+DEV_ISSUER			:= https://auth-dev.mozilla.auth0.com/
+PROD_PROVIDER_ARNS	:= arn:aws:iam::415589142697:oidc-provider/auth.mozilla.auth0.com/
+DEV_PROVIDER_ARNS	:= arn:aws:iam::415589142697:oidc-provider/auth-dev.mozilla.auth0.com/
+PROD_AMR_CLAIMS		:= auth.mozilla.auth0.com/:amr
+DEV_AMR_CLAIMS		:= auth-dev.mozilla.auth0.com/:amr
 
 .PHONE: deploy-group-role-map-builder
 deploy-group-role-map-builder:
@@ -23,7 +31,8 @@ deploy-group-role-map-builder:
 		 group_role_map_builder/group_role_map_builder.yaml \
 		 $(PROD_S3_BUCKET_NAME) \
 		 $(GROUP_ROLE_MAP_BUILDER_STACK_NAME) \
-		 $(GROUP_ROLE_MAP_BUILDER_CODE_STORAGE_S3_PREFIX)
+		 $(GROUP_ROLE_MAP_BUILDER_CODE_STORAGE_S3_PREFIX) \
+		 "ProviderArns=$(PROD_PROVIDER_ARNS) AmrClaims=$(PROD_AMR_CLAIMS)"
 
 .PHONE: deploy-group-role-map-builder-dev
 deploy-group-role-map-builder-dev:
@@ -32,7 +41,8 @@ deploy-group-role-map-builder-dev:
 		 group_role_map_builder/group_role_map_builder.yaml \
 		 $(DEV_S3_BUCKET_NAME) \
 		 $(GROUP_ROLE_MAP_BUILDER_STACK_NAME) \
-		 $(GROUP_ROLE_MAP_BUILDER_CODE_STORAGE_S3_PREFIX)
+		 $(GROUP_ROLE_MAP_BUILDER_CODE_STORAGE_S3_PREFIX) \
+		 "ProviderArns=$(DEV_PROVIDER_ARNS) AmrClaims=$(DEV_AMR_CLAIMS)"
 
 .PHONE: deploy-idtoken-for-roles-dev
 deploy-idtoken-for-roles-dev:
@@ -42,7 +52,7 @@ deploy-idtoken-for-roles-dev:
 		 $(DEV_S3_BUCKET_NAME) \
 		 $(IDTOKEN_FOR_ROLES_STACK_NAME) \
 		 $(IDTOKEN_FOR_ROLES_CODE_STORAGE_S3_PREFIX) \
-		 "CustomDomainName=$(DEV_DOMAIN_NAME) DomainNameZone=$(DEV_DOMAIN_ZONE) CertificateArn=$(DEV_CERT_ARN)" \
+		 "CustomDomainName=$(DEV_DOMAIN_NAME) DomainNameZone=$(DEV_DOMAIN_ZONE) CertificateArn=$(DEV_CERT_ARN) AllowedIssuer=$(DEV_ISSUER) AllowedAudience=$(DEV_CLIENT_ID)" \
 		 AliasesEndpointUrl
 
 .PHONE: deploy-idtoken-for-roles
@@ -53,7 +63,7 @@ deploy-idtoken-for-roles:
 		 $(PROD_S3_BUCKET_NAME) \
 		 $(IDTOKEN_FOR_ROLES_STACK_NAME) \
 		 $(IDTOKEN_FOR_ROLES_CODE_STORAGE_S3_PREFIX) \
-		 "CustomDomainName=$(PROD_DOMAIN_NAME) DomainNameZone=$(PROD_DOMAIN_ZONE) CertificateArn=$(PROD_CERT_ARN)" \
+		 "CustomDomainName=$(PROD_DOMAIN_NAME) DomainNameZone=$(PROD_DOMAIN_ZONE) CertificateArn=$(PROD_CERT_ARN) AllowedIssuer=$(PROD_ISSUER) AllowedAudience=$(PROD_CLIENT_ID)" \
 		 AliasesEndpointUrl
 
 .PHONE: test-idtoken-for-roles

--- a/cloudformation/group_role_map_builder/group_role_map_builder.yaml
+++ b/cloudformation/group_role_map_builder/group_role_map_builder.yaml
@@ -15,6 +15,11 @@ Metadata:
       - S3BucketName
       - GroupRoleMapS3FilePath
       - AccountAliasesS3FilePath
+    - Label:
+        default: OIDC Configuration
+      Parameters:
+      - ProviderArns
+      - AmrClaims
     ParameterLabels:
       StackEmissionDynamoDBTableName:
         default: Stack Emission DynamoDB Table Name
@@ -46,6 +51,12 @@ Parameters:
     Type: String
     Description: The path to the account aliases map file
     Default: account-aliases.json
+  ProviderArns:
+    Type: String
+    Description: A comma delimited list of AWS IAM OIDC Provider ARNs
+  AmrClaims:
+    Type: String
+    Description: A comma delimited list of OIDC AMR claim names
 Resources:
   GroupRoleMapBuilderRole:
     Type: AWS::IAM::Role
@@ -122,6 +133,8 @@ Resources:
           S3_BUCKET_NAME: !Ref S3BucketName
           S3_FILE_PATH_GROUP_ROLE_MAP: !Ref GroupRoleMapS3FilePath
           S3_FILE_PATH_ALIAS_MAP: !Ref AccountAliasesS3FilePath
+          VALID_FEDERATED_PRINCIPAL_KEYS: !Ref ProviderArns
+          VALID_AMRS: !Ref AmrClaims
       Handler: group_role_map_builder.lambda_handler
       Runtime: python3.7
       Role: !GetAtt GroupRoleMapBuilderRole.Arn

--- a/cloudformation/group_role_map_builder/tests/policies/invalid_stringequals_multiple_groups_with_glob.json
+++ b/cloudformation/group_role_map_builder/tests/policies/invalid_stringequals_multiple_groups_with_glob.json
@@ -5,7 +5,7 @@
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::656532927350:oidc-provider/auth-dev.mozilla.auth0.com/"
+        "Federated": "arn:aws:iam::123456789012:oidc-provider/auth.example.auth0.com/"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
@@ -13,7 +13,7 @@
           "auth-dev.mozilla.auth0.com/:aud": "xRFzU2bj7Lrbo3875aXwyxIArdkq1AOT"
         },
         "ForAnyValue:StringEquals": {
-          "auth-dev.mozilla.auth0.com/:amr": ["one_group", "two_groups*", "three_groups"]
+          "auth.example.auth0.com/:amr": ["one_group", "two_groups*", "three_groups"]
         }
       }
     }

--- a/cloudformation/group_role_map_builder/tests/policies/invalid_stringequals_one_group_with_glob.json
+++ b/cloudformation/group_role_map_builder/tests/policies/invalid_stringequals_one_group_with_glob.json
@@ -5,7 +5,7 @@
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::656532927350:oidc-provider/auth-dev.mozilla.auth0.com/"
+        "Federated": "arn:aws:iam::123456789012:oidc-provider/auth.example.auth0.com/"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
@@ -13,7 +13,7 @@
           "auth-dev.mozilla.auth0.com/:aud": "xRFzU2bj7Lrbo3875aXwyxIArdkq1AOT"
         },
         "ForAnyValue:StringEquals": {
-          "auth-dev.mozilla.auth0.com/:amr": "one_group*"
+          "auth.example.auth0.com/:amr": "one_group*"
         }
       }
     }

--- a/cloudformation/group_role_map_builder/tests/policies/invalid_stringequals_one_group_with_question_mark.json
+++ b/cloudformation/group_role_map_builder/tests/policies/invalid_stringequals_one_group_with_question_mark.json
@@ -5,7 +5,7 @@
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::656532927350:oidc-provider/auth-dev.mozilla.auth0.com/"
+        "Federated": "arn:aws:iam::123456789012:oidc-provider/auth.example.auth0.com/"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
@@ -13,7 +13,7 @@
           "auth-dev.mozilla.auth0.com/:aud": "xRFzU2bj7Lrbo3875aXwyxIArdkq1AOT"
         },
         "ForAnyValue:StringEquals": {
-          "auth-dev.mozilla.auth0.com/:amr": "one_?group"
+          "auth.example.auth0.com/:amr": "one_?group"
         }
       }
     }

--- a/cloudformation/group_role_map_builder/tests/policies/multiple_groups_stringlike.json
+++ b/cloudformation/group_role_map_builder/tests/policies/multiple_groups_stringlike.json
@@ -5,7 +5,7 @@
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::656532927350:oidc-provider/auth-dev.mozilla.auth0.com/"
+        "Federated": "arn:aws:iam::123456789012:oidc-provider/auth.example.auth0.com/"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
@@ -13,7 +13,7 @@
           "auth-dev.mozilla.auth0.com/:aud": "xRFzU2bj7Lrbo3875aXwyxIArdkq1AOT"
         },
         "ForAnyValue:StringLike": {
-          "auth-dev.mozilla.auth0.com/:amr": ["one_group", "two_groups", "three_groups*"]
+          "auth.example.auth0.com/:amr": ["one_group", "two_groups", "three_groups*"]
         }
       }
     }

--- a/cloudformation/group_role_map_builder/tests/policies/no_conditions.json
+++ b/cloudformation/group_role_map_builder/tests/policies/no_conditions.json
@@ -5,7 +5,7 @@
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::656532927350:oidc-provider/auth-dev.mozilla.auth0.com/"
+        "Federated": "arn:aws:iam::123456789012:oidc-provider/auth.example.auth0.com/"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {

--- a/cloudformation/group_role_map_builder/tests/policies/one_group_stringequals.json
+++ b/cloudformation/group_role_map_builder/tests/policies/one_group_stringequals.json
@@ -5,7 +5,7 @@
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::656532927350:oidc-provider/auth-dev.mozilla.auth0.com/"
+        "Federated": "arn:aws:iam::123456789012:oidc-provider/auth.example.auth0.com/"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
@@ -13,7 +13,7 @@
           "auth-dev.mozilla.auth0.com/:aud": "xRFzU2bj7Lrbo3875aXwyxIArdkq1AOT"
         },
         "ForAnyValue:StringEquals": {
-          "auth-dev.mozilla.auth0.com/:amr": "one_group"
+          "auth.example.auth0.com/:amr": "one_group"
         }
       }
     }

--- a/cloudformation/group_role_map_builder/tests/policies/one_group_stringlike.json
+++ b/cloudformation/group_role_map_builder/tests/policies/one_group_stringlike.json
@@ -5,7 +5,7 @@
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::656532927350:oidc-provider/auth-dev.mozilla.auth0.com/"
+        "Federated": "arn:aws:iam::123456789012:oidc-provider/auth.example.auth0.com/"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
@@ -13,7 +13,7 @@
           "auth-dev.mozilla.auth0.com/:aud": "xRFzU2bj7Lrbo3875aXwyxIArdkq1AOT"
         },
         "ForAnyValue:StringLike": {
-          "auth-dev.mozilla.auth0.com/:amr": "one_group"
+          "auth.example.auth0.com/:amr": "one_group"
         }
       }
     }

--- a/cloudformation/group_role_map_builder/tests/policies/unknown_amr.json
+++ b/cloudformation/group_role_map_builder/tests/policies/unknown_amr.json
@@ -5,7 +5,7 @@
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::656532927350:oidc-provider/auth-dev.mozilla.auth0.com/"
+        "Federated": "arn:aws:iam::123456789012:oidc-provider/auth.example.auth0.com/"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
@@ -13,7 +13,7 @@
           "auth-dev.mozilla.auth0.com/:aud": "xRFzU2bj7Lrbo3875aXwyxIArdkq1AOT"
         },
         "ForAnyValue:StringLike": {
-          "auth-dev.mozilla.authzero.com/:amr": "one_group"
+          "auth.thisissomeotheridp.auth0.com/:amr": "one_group"
         }
       }
     }

--- a/cloudformation/group_role_map_builder/tests/policies/unknown_arn.json
+++ b/cloudformation/group_role_map_builder/tests/policies/unknown_arn.json
@@ -5,7 +5,7 @@
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::1337:oidc-provider/auth-dev.mozilla.auth0.com/"
+        "Federated": "arn:aws:iam::111111111111:oidc-provider/auth.thisisadifferentidp.auth0.com/"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
@@ -13,7 +13,7 @@
           "auth-dev.mozilla.auth0.com/:aud": "xRFzU2bj7Lrbo3875aXwyxIArdkq1AOT"
         },
         "ForAnyValue:StringLike": {
-          "auth-dev.mozilla.auth0.com/:amr": "one_group"
+          "auth.example.auth0.com/:amr": "one_group"
         }
       }
     }

--- a/cloudformation/group_role_map_builder/tests/policies/unsupported_too_many_conditions.json
+++ b/cloudformation/group_role_map_builder/tests/policies/unsupported_too_many_conditions.json
@@ -5,15 +5,15 @@
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::656532927350:oidc-provider/auth-dev.mozilla.auth0.com/"
+        "Federated": "arn:aws:iam::123456789012:oidc-provider/auth.example.auth0.com/"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "auth-dev.mozilla.auth0.com/:amr": "one_group"
+          "auth.example.auth0.com/:amr": "one_group"
         },
         "ForAnyValue:StringLike": {
-          "auth-dev.mozilla.auth0.com/:amr": "two_groups*"
+          "auth.example.auth0.com/:amr": "two_groups*"
         }
       }
     }

--- a/cloudformation/group_role_map_builder/tests/test_compare_group_arn_maps.py
+++ b/cloudformation/group_role_map_builder/tests/test_compare_group_arn_maps.py
@@ -1,13 +1,13 @@
 from unittest.mock import patch
 from ..functions.group_role_map_builder import (
     store_s3_file,
-    get_s3_file,
-    S3_BUCKET_NAME,
+    get_s3_file
 )
 from ..functions import group_role_map_builder
 import boto3
 from moto import mock_s3
 
+S3_BUCKET_NAME = 'test'
 S3_FILE_NAME = 'test.json'
 
 # https://stackoverflow.com/a/23844656/168874

--- a/cloudformation/group_role_map_builder/tests/test_get_secuity_audit_role_arns.py
+++ b/cloudformation/group_role_map_builder/tests/test_get_secuity_audit_role_arns.py
@@ -1,18 +1,12 @@
 import boto3
 from moto import mock_dynamodb2
 from ..functions.group_role_map_builder import get_security_audit_role_arns
-from ..functions.group_role_map_builder import (
-    TABLE_CATEGORY,
-    TABLE_INDEX_NAME,
-    TABLE_ATTRIBUTE_NAME,
-    TABLE_NAME,
-    TABLE_REGION,
-)
+from ..functions.group_role_map_builder import get_setting
 
 # https://github.com/mozilla/cloudformation-cross-account-outputs/blob/master/cloudformation/cloudformation-stack-emissions-dynamodb.yml
 TABLE_PRIMARY_HASH_ATTRIBUTE = 'aws-account-id'
 TABLE_PRIMARY_RANGE_ATTRIBUTE = 'id'
-TABLE_SECONDARY_HASH_ATTRIBUTE = TABLE_INDEX_NAME
+TABLE_SECONDARY_HASH_ATTRIBUTE = get_setting('TABLE_INDEX_NAME')
 TABLE_SECONDARY_RANGE_ATTRIBUTE = TABLE_PRIMARY_RANGE_ATTRIBUTE
 
 # Test values
@@ -30,7 +24,7 @@ def create_dynamodb_table():
 
     https://github.com/mozilla/cloudformation-cross-account-outputs/blob/master/cloudformation/cloudformation-stack-emissions-dynamodb.yml
     """
-    client = boto3.client('dynamodb', region_name=TABLE_REGION)
+    client = boto3.client('dynamodb', region_name=get_setting('TABLE_REGION'))
     client.create_table(
         AttributeDefinitions=[
             {
@@ -46,7 +40,7 @@ def create_dynamodb_table():
                 'AttributeType': 'S',
             },
         ],
-        TableName=TABLE_NAME,
+        TableName=get_setting('TABLE_NAME'),
         KeySchema=[
             {'AttributeName': TABLE_PRIMARY_HASH_ATTRIBUTE, 'KeyType': 'HASH'},
             {
@@ -78,20 +72,21 @@ def add_records_to_table():
     """Add testing data to mocked DynamoDB table"""
     item = {
         TABLE_PRIMARY_HASH_ATTRIBUTE: AWS_ACCOUNT_ID,
-        TABLE_INDEX_NAME: TABLE_CATEGORY,
+        get_setting('TABLE_INDEX_NAME'): get_setting('TABLE_CATEGORY'),
         TABLE_PRIMARY_RANGE_ATTRIBUTE: '{}+{}'.format(
             STACK_ID, LOGICAL_RESOURCE_ID
         ),
         'last-updated': '2019-02-07T18:40:44.525270Z',
         'logical-resource-id': LOGICAL_RESOURCE_ID,
         'region': 'us-west-2',
-        TABLE_ATTRIBUTE_NAME: IAM_ROLE_ARN,
+        get_setting('TABLE_ATTRIBUTE_NAME'): IAM_ROLE_ARN,
         'SecurityAuditIAMRoleName': IAM_ROLE_NAME,
         'stack-id': STACK_ID,
         'stack-name': 'InfosecClientRoleSecurityAudit',
     }
-    dynamodb = boto3.resource('dynamodb', region_name=TABLE_REGION)
-    table = dynamodb.Table(TABLE_NAME)
+    dynamodb = boto3.resource(
+        'dynamodb', region_name=get_setting('TABLE_REGION'))
+    table = dynamodb.Table(get_setting('TABLE_NAME'))
     table.put_item(Item=item)
 
 

--- a/cloudformation/idtoken_for_roles/idtoken_for_roles.yaml
+++ b/cloudformation/idtoken_for_roles/idtoken_for_roles.yaml
@@ -59,11 +59,9 @@ Parameters:
   AllowedIssuer:
     Type: String
     Description: OIDC Issuer Identifier
-    Default: https://auth-dev.mozilla.auth0.com/
   AllowedAudience:
     Type: String
     Description: OIDC Audience. For Mozilla this is the Auth0 Client ID
-    Default: xRFzU2bj7Lrbo3875aXwyxIArdkq1AOT
   RolesPathPrefix:
     Type: String
     Description: The URL path prefix to POST ID tokens to and get back roles

--- a/federated_aws_cli/cli.py
+++ b/federated_aws_cli/cli.py
@@ -108,9 +108,9 @@ def main(config, role_arn, output, verbose):
     logger.debug("Config : {}".format(config))
 
     # Instantiate a login object, and begin login process
-    login = Login()
-    login.configure(
-        authorization_endpoint=config["openid-configuration"]["authorization_endpoint"],
+    login = Login(
+        authorization_endpoint=config["openid-configuration"][
+            "authorization_endpoint"],
         client_id=config["client_id"],
         idtoken_for_roles_url=config["idtoken_for_roles_url"],
         jwks=config["jwks"],

--- a/federated_aws_cli/login.py
+++ b/federated_aws_cli/login.py
@@ -10,7 +10,8 @@ import requests
 
 from federated_aws_cli import sts_conn
 from federated_aws_cli.listener import listen, port
-from federated_aws_cli.role_picker import get_aws_env_variables, get_roles_and_aliases, show_role_picker
+from federated_aws_cli.role_picker import (
+    get_aws_env_variables, get_roles_and_aliases, show_role_picker)
 
 
 try:
@@ -37,25 +38,27 @@ def base64_without_padding(data):
 
 def generate_challenge(code_verifier):
     # https://tools.ietf.org/html/rfc7636#section-4.2
-    return base64_without_padding(hashlib.sha256(code_verifier.encode()).digest())
+    return base64_without_padding(
+        hashlib.sha256(code_verifier.encode()).digest())
 
 
-class Login():
+class Login:
     # Maybe this would be better to unroll from config?
-    def configure(
-                  self,
-                  authorization_endpoint="https://auth.mozilla.auth0.com/authorize",
-                  client_id="",
-                  idtoken_for_roles_url=None,
-                  jwks=None,
-                  openid_configuration=None,
-                  output=None,
-                  role_arn=None,
-                  scope="openid",
-                  token_endpoint="https://auth.mozilla.auth0.com/oauth/token",
-                  ):
+    def __init__(
+        self,
+        authorization_endpoint="https://auth.mozilla.auth0.com/authorize",
+        client_id="",
+        idtoken_for_roles_url=None,
+        jwks=None,
+        openid_configuration=None,
+        output=None,
+        role_arn=None,
+        scope="openid",
+        token_endpoint="https://auth.mozilla.auth0.com/oauth/token",
+    ):
 
-        # URL of the OIDC authorization endpoint obtained from the discovery document
+        # URL of the OIDC authorization endpoint obtained from the discovery
+        # document
         self.authorization_endpoint = authorization_endpoint
 
         # OIDC client_id of the native OIDC application
@@ -78,11 +81,12 @@ class Login():
         self.token_endpoint = token_endpoint
 
     def login(self):
-        """Follow the PKCE auth flow by spawning a browser for the user to login,
-        passing a redirect_uri that points to a localhost listener. Once the user
-        logs into the IdP in the browser, the IdP will redirect the user to the
-        localhost listener, making the OIDC code available to the CLI. CLI then
-        exchanges the code for an tokens with the IdP and returns the tokens
+        """Follow the PKCE auth flow by spawning a browser for the user to
+        login, passing a redirect_uri that points to a localhost listener. Once
+        the user logs into the IdP in the browser, the IdP will redirect the
+        user to the localhost listener, making the OIDC code available to the
+        CLI. CLI then exchanges the code for an tokens with the IdP and returns
+        the tokens
 
         :return: Nothing, as the callback will send SIGINT to terminate
         """
@@ -96,18 +100,21 @@ class Login():
             "state": self.state,
         }
 
-        # We don't set audience here because Auth0 will set the audience on it's
-        # own
+        # We don't set audience here because Auth0 will set the audience on
+        # it's own
         url = "{}?{}".format(self.authorization_endpoint,
                              urlencode(url_parameters))
 
         # Open the browser window to the login url
 
-        # Previously we needed to call webbrowser.get() passing 'firefox' as an argument to the get method
-        # This was to work around webbrowser.BackgroundBrowser[1] sending the browsers stdout/stderr to the console.
-        # That output to the console would then corrupt the intended script output meant to be eval'd. This issue doesn't
-        # appear to be manifesting anymore and so we've set it back to the default of whatever browser the OS uses.
-        # [1]: https://github.com/python/cpython/blob/783b794a5e6ea3bbbaba45a18b9e03ac322b3bd4/Lib/webbrowser.py#L177-L181
+        # Previously we needed to call webbrowser.get() passing 'firefox' as an
+        # argument to the get method. This was to work around
+        # webbrowser.BackgroundBrowser[1] sending the browsers stdout/stderr to
+        # the console. That output to the console would then corrupt the
+        # intended script output meant to be eval'd. This issue doesn't appear
+        # to be manifesting anymore and so we've set it back to the default of
+        # whatever browser the OS uses.
+        # [1]: https://github.com/python/cpython/blob/783b794a5e6ea3bbbaba45a18b9e03ac322b3bd4/Lib/webbrowser.py#L177-L181  # noqa
         logger.debug("About to spawn browser window to {}".format(url))
         webbrowser.get().open_new_tab(url)
 
@@ -141,7 +148,8 @@ class Login():
             "redirect_uri": self.redirect_uri,
         }
 
-        token = requests.post(self.token_endpoint, headers=headers, json=body).json()
+        token = requests.post(
+            self.token_endpoint, headers=headers, json=body).json()
 
         logger.debug("Validating response from endpoint: {}".format(token))
 
@@ -161,7 +169,8 @@ class Login():
                     token=token["id_token"],
                     key=self.jwks
                 )
-                logger.debug('Roles and aliases are {}'.format(roles_and_aliases))
+                logger.debug(
+                    'Roles and aliases are {}'.format(roles_and_aliases))
                 self.role_arn = show_role_picker(roles_and_aliases, message)
                 logger.debug('Role ARN {} selected'.format(self.role_arn))
             if self.role_arn is None:

--- a/federated_aws_cli/role_picker.py
+++ b/federated_aws_cli/role_picker.py
@@ -41,12 +41,13 @@ def get_roles_and_aliases(endpoint, token, key):
     return r.json()
 
 
-def show_menu(menu_selections, role_arns):
+def show_menu(menu_selections, role_arns, message=None):
     """Display a set of menu selections and return the associated role_arn
     once the user selects a role
 
     :param list menu_selections: A list of menu selections to display
     :param list role_arns: A list of IAM Role ARNs
+    :param str message: An optional message to show in the menu
     :return: The IAM Role ARN selected
     """
     screen = consolemenu.Screen()
@@ -58,6 +59,7 @@ def show_menu(menu_selections, role_arns):
     menu = consolemenu.ConsoleMenu(
         title="Select which AWS account and IAM role you'd like to assume",
         subtitle="Account Alias (Account ID) : Role Name",
+        prologue_text=message,
         screen=screen,
         formatter=formatter
     )
@@ -68,7 +70,7 @@ def show_menu(menu_selections, role_arns):
             if menu.selected_option != len(menu_selections) else None)
 
 
-def show_role_picker(roles_and_aliases):
+def show_role_picker(roles_and_aliases, message=None):
     """Display an IAM Role picker menu and return the role picked by the user
 
     :param dict roles_and_aliases: A dict with two keys, 'roles' and 'aliases'
@@ -82,6 +84,7 @@ def show_role_picker(roles_and_aliases):
                 '234567890123': ['Mountains-Account'],
             }
         }
+    :param str message: An optional message to show in the menu
     :return: The IAM Role ARN that was selected by the user
     """
     role_arns = roles_and_aliases.get('roles', [])
@@ -108,5 +111,5 @@ def show_role_picker(roles_and_aliases):
             menu_selections.append('{} ({}) : {}'.format(
                 account_alias, alias_to_id[account_alias], role_name))
             role_arns.append(options[account_alias][role_name])
-    result = show_menu(menu_selections, role_arns)
+    result = show_menu(menu_selections, role_arns, message)
     return result

--- a/federated_aws_cli/sts_conn.py
+++ b/federated_aws_cli/sts_conn.py
@@ -31,7 +31,7 @@ def get_credentials(bearer_token, role_arn):
     resp = requests.get(url=sts_url, params=parameters)
     if resp.status_code != requests.codes.ok:
         logger.error('AWS STS Call failed {} : {}'.format(resp.status_code, resp.text))
-        return False
+        return None
 
     logger.debug('STS Call Response headers : {}'.format(resp.headers))
     logger.debug('STS Call Response : {}'.format(resp.text))

--- a/tests/test_federated_aws_cli.py
+++ b/tests/test_federated_aws_cli.py
@@ -90,5 +90,5 @@ def test_show_role_picker(show_menu):
          'arn:aws:iam::234567890123:role/path/to/foraker',
          'arn:aws:iam::123456789012:role/role-mariana',
          'arn:aws:iam::123456789012:role/a/path/role-philippine',
-         'arn:aws:iam::123456789012:role/role-tonga']
+         'arn:aws:iam::123456789012:role/role-tonga'], None
     )


### PR DESCRIPTION
* Move login.configure to `__init__` and meet PEP008 needs
* Gracefully deal with cases where the STS call fails
* Pass in more prod and dev specific values
  * Removes hardcoded defaults and passes those values in via the Makefile
* Improve tests
  * Remove real values from tests and replace with example values
  * Move configuration settings that exist as constants at the root
    of the module to a set of DEFAULTS and a get_settings method to
    fetch them. This enables overriding these settings in unit tests
    as resolving the environment variables and the defaults happens
    at invocation instead of at module import time.
  * Add clarifying output text to test_get_groups_from_policy. This
    was needed because the assertions and exception checks don't
    reveal which policy is failing.
