### PR TITLE
Fix bugs introduced during merge and conflict resolution

### DIFF
--- a/federated_aws_cli/login.py
+++ b/federated_aws_cli/login.py
@@ -135,13 +135,22 @@ class Login:
         else:
             self.callback(None, None, token=token)
 
-    def callback(self, code, state, token=None):
+    def callback(self, code, state, token=None, **kwargs):
         """
         :param code: code GET paramater as sent by IdP
         :param state: state GET parameter as sent by IdP
         :param token: cached token (if available)
+        :param kwargs: remaining optional arguments passed back to the redirect
+                       URI. For example 'error' and 'error_description'
         :return:
         """
+        if kwargs.get('error'):
+            print(
+                "Received an error response from the identity provider in "
+                "response to the /authorize request : {}".format(
+                    kwargs.get('error_description')))
+            exit_sigint()
+
         if token is None:  # Callback from web listener
             if code is None:
                 print("Something wrong happened, could not retrieve session data")


### PR DESCRIPTION
This fixes bugs introduced in https://github.com/mozilla-iam/federated-aws-cli/pull/85/commits/7a2be16daaecae23a3c39ebb8c1b32233bc8a4e7

which was squashed into f740aed6db53cecbb5c11d6459fa89068dbb4551

By recreating the changes that were lost from https://github.com/mozilla-iam/federated-aws-cli/pull/85/commits/043ab598cb65fcea4fd22177b5a200d03add77a7

That provide "Pass all query parameters through so that error messages are passed"

This is the second of two bugs introduced in that conflict solving merge commit, the other one fixed in https://github.com/mozilla-iam/federated-aws-cli/pull/85/commits/9fe74a1a35901bb49ebbf47ca3be85439227ace7