### PR TITLE
 Change template to support both mustache and handlebars 

### DIFF
--- a/cloudformation/Makefile
+++ b/cloudformation/Makefile
@@ -29,30 +29,30 @@ deploy-group-role-map-builder:
 	./deploy.sh \
 		 $(PROD_ACCOUNT_ID) \
 		 group_role_map_builder/group_role_map_builder.yaml \
-		 $(PROD_S3_BUCKET_NAME) \
+		 $(PROD_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME) \
 		 $(GROUP_ROLE_MAP_BUILDER_STACK_NAME) \
 		 $(GROUP_ROLE_MAP_BUILDER_CODE_STORAGE_S3_PREFIX) \
-		 "ProviderUrls=$(PROD_PROVIDER_URLS) AmrClaims=$(PROD_AMR_CLAIMS)"
+		 "S3BucketName=$(PROD_S3_BUCKET_NAME) ProviderUrls=$(PROD_PROVIDER_URLS) AmrClaims=$(PROD_AMR_CLAIMS)"
 
 .PHONE: deploy-group-role-map-builder-dev
 deploy-group-role-map-builder-dev:
 	./deploy.sh \
 		 $(DEV_ACCOUNT_ID) \
 		 group_role_map_builder/group_role_map_builder.yaml \
-		 $(DEV_S3_BUCKET_NAME) \
+		 $(DEV_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME) \
 		 $(GROUP_ROLE_MAP_BUILDER_STACK_NAME) \
 		 $(GROUP_ROLE_MAP_BUILDER_CODE_STORAGE_S3_PREFIX) \
-		 "ProviderUrls=$(DEV_PROVIDER_URLS) AmrClaims=$(DEV_AMR_CLAIMS)"
+		 "S3BucketName=$(DEV_S3_BUCKET_NAME) ProviderUrls=$(DEV_PROVIDER_URLS) AmrClaims=$(DEV_AMR_CLAIMS)"
 
 .PHONE: deploy-idtoken-for-roles-dev
 deploy-idtoken-for-roles-dev:
 	./deploy.sh \
 		 $(DEV_ACCOUNT_ID) \
 		 idtoken_for_roles/idtoken_for_roles.yaml \
-		 $(DEV_S3_BUCKET_NAME) \
+		 $(DEV_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME) \
 		 $(IDTOKEN_FOR_ROLES_STACK_NAME) \
 		 $(IDTOKEN_FOR_ROLES_CODE_STORAGE_S3_PREFIX) \
-		 "CustomDomainName=$(DEV_DOMAIN_NAME) DomainNameZone=$(DEV_DOMAIN_ZONE) CertificateArn=$(DEV_CERT_ARN) AllowedIssuer=$(DEV_ISSUER) AllowedAudience=$(DEV_CLIENT_ID)" \
+		 "S3BucketName=$(DEV_S3_BUCKET_NAME) CustomDomainName=$(DEV_DOMAIN_NAME) DomainNameZone=$(DEV_DOMAIN_ZONE) CertificateArn=$(DEV_CERT_ARN) AllowedIssuer=$(DEV_ISSUER) AllowedAudience=$(DEV_CLIENT_ID)" \
 		 AliasesEndpointUrl
 
 .PHONE: deploy-idtoken-for-roles
@@ -60,10 +60,10 @@ deploy-idtoken-for-roles:
 	./deploy.sh \
 		 $(PROD_ACCOUNT_ID) \
 		 idtoken_for_roles/idtoken_for_roles.yaml \
-		 $(PROD_S3_BUCKET_NAME) \
+		 $(PROD_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME) \
 		 $(IDTOKEN_FOR_ROLES_STACK_NAME) \
 		 $(IDTOKEN_FOR_ROLES_CODE_STORAGE_S3_PREFIX) \
-		 "CustomDomainName=$(PROD_DOMAIN_NAME) DomainNameZone=$(PROD_DOMAIN_ZONE) CertificateArn=$(PROD_CERT_ARN) AllowedIssuer=$(PROD_ISSUER) AllowedAudience=$(PROD_CLIENT_ID)" \
+		 "S3BucketName=$(PROD_S3_BUCKET_NAME) CustomDomainName=$(PROD_DOMAIN_NAME) DomainNameZone=$(PROD_DOMAIN_ZONE) CertificateArn=$(PROD_CERT_ARN) AllowedIssuer=$(PROD_ISSUER) AllowedAudience=$(PROD_CLIENT_ID)" \
 		 AliasesEndpointUrl
 
 .PHONE: test-idtoken-for-roles

--- a/cloudformation/deploy.sh
+++ b/cloudformation/deploy.sh
@@ -5,7 +5,7 @@ ACCOUNT_ID=$1
 # idtoken_for_roles/idtoken_for_roles.yaml
 TEMPLATE_FILENAME=$2
 # DEV_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME
-S3_BUCKET=$3
+S3_BUCKET_CODE_STORAGE=$3
 # GroupRoleMapBuilder
 STACK_NAME=$4
 # group-role-map-builder
@@ -57,7 +57,6 @@ fi
 aws cloudformation deploy --template-file $TMPFILE --stack-name $STACK_NAME \
   --capabilities CAPABILITY_IAM \
   --parameter-overrides \
-    S3BucketName=$S3_BUCKET \
     $PARAMETER_OVERRIDES
 
 echo "Waiting for stack to reach a COMPLETE state"

--- a/federated_aws_cli/listener.py
+++ b/federated_aws_cli/listener.py
@@ -164,7 +164,7 @@ def listen(login):
     # set the global callback
     globals()["login"] = login
 
-    debug = logger.level == 10  # DEBUG
+    debug = True if logger.level == logging.DEBUG else False
 
     # Disable flask logging unless we're at DEBUG
     if not debug:

--- a/federated_aws_cli/listener.py
+++ b/federated_aws_cli/listener.py
@@ -70,16 +70,13 @@ def set_role():
 
 @app.route("/api/roles", methods=["GET"])
 def get_roles():
-    roles = {
-        "roles": []
-    }
-
+    roles = []
     for arn in login.role_map["roles"]:
         account_id = arn.split(":")[4]
         alias = login.role_map.get("aliases", {}).get(account_id, [account_id])[0]
         role = arn.split(':')[5].split('/')[-1]
 
-        roles["roles"].append(
+        roles.append(
             {
                 "alias": alias,
                 "arn": arn,
@@ -89,7 +86,7 @@ def get_roles():
         )
 
     # Sort the list by role name
-    roles["roles"] = sorted(roles["roles"], key=itemgetter("role"))
+    roles = sorted(roles, key=itemgetter("role"))
 
     # Set the state to stop polling for new roles
     login.state = "awaiting_role"

--- a/federated_aws_cli/static/index.html
+++ b/federated_aws_cli/static/index.html
@@ -26,9 +26,9 @@
 
     <script id="role-picker-template" type="text-/x-handlebars-template">
       <ul>
-          {{#each .}}
-          <li><a data-arn="{{this.arn}}" data-role="{{this.role}}" href="#{{this.arn}}">{{this.role}}</a><br><span style="margin-left: 2em;">Account: {{this.alias}} ({{this.id}})</span></li>
-          {{/each}}
+          {{#roles}}
+          <li><a data-arn="{{arn}}" data-role="{{role}}" href="#{{arn}}">{{role}}</a><br><span style="margin-left: 2em;">Account: {{alias}} ({{id}})</span></li>
+          {{/roles}}
       </ul>
     </script>
 

--- a/federated_aws_cli/static/index.js
+++ b/federated_aws_cli/static/index.js
@@ -28,7 +28,7 @@ const selectRole = async (e) => {
 };
 
 const showRoles = async (roles, message) => {
-    if (roles.length === 0) {
+    if (roles["roles"].length === 0) {
         await shutdown();
         setMessage("Sorry, no roles available. You may now close this window.");
         return;
@@ -94,7 +94,7 @@ const pollState = setInterval(async () => {
 
         // show the roles
         const roles = await response.json();
-        showRoles(roles["roles"]);
+        showRoles(roles);
     } else if (remoteState.state === "aws_federate") {
         setMessage("Redirecting to AWS...");
         await shutdown();

--- a/federated_aws_cli/static/index.js
+++ b/federated_aws_cli/static/index.js
@@ -28,7 +28,7 @@ const selectRole = async (e) => {
 };
 
 const showRoles = async (roles, message) => {
-    if (roles["roles"].length === 0) {
+    if (roles.length === 0) {
         await shutdown();
         setMessage("Sorry, no roles available. You may now close this window.");
         return;
@@ -38,7 +38,7 @@ const showRoles = async (roles, message) => {
     const template = Handlebars.compile(source);
 
     // display the role options on the page
-    $("#role-picker").html(template(roles)).removeClass("hidden");
+    $("#role-picker").html(template({"roles": roles})).removeClass("hidden");
 
     // set the event handlers on the newly created nodes
     $("a[data-arn]").on("click", selectRole);

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,4 @@ setenv =
     PYTHONPATH = {toxinidir}
 deps = .[test]
 commands =
-    pytest --cov=federated_aws_cli --ignore cloudformation {posargs}
+    pytest --cov=federated_aws_cli --ignore cloudformation --capture=no {posargs}


### PR DESCRIPTION
* Try to provision a 12 hour session and fall back to 1 hour if that fails
* Clarify how the debug variable is set
* Fix the Makefile S3 bucket names
  * Previously, the template files were being stored in the Auth0 asset bucket by mistake
* Set tox to set pytest to not capture logs/output from the tests and instead pass it through.
  * This should make debugging easier

