### PR TITLE
Add support for redirecting to the web RP when the web session expires

### DIFF
--- a/federated_aws_cli/cli.py
+++ b/federated_aws_cli/cli.py
@@ -145,6 +145,7 @@ def main(batch, config, no_cache, output, role_arn, verbose, web_console):
         scope=config["scope"],
         token_endpoint=config["openid-configuration"]["token_endpoint"],
         web_console=web_console,
+        issuer_domain=config.get("issuer_domain", "aws.security.mozilla.com")
     )
 
     login.login()

--- a/federated_aws_cli/login.py
+++ b/federated_aws_cli/login.py
@@ -55,7 +55,7 @@ class Login:
         scope="openid",
         token_endpoint="https://auth.mozilla.auth0.com/oauth/token",
         web_console=False,
-        issuer_domain=None
+        issuer_domain=None,
     ):
 
         # We use this for tracking various bits
@@ -360,7 +360,7 @@ class Login:
             "Action": "login",
             "Destination": "https://console.aws.amazon.com/",
             "SigninToken": token["SigninToken"],
-            "Issuer": issuer_url
+            "Issuer": issuer_url,
         })
         url = urlunparse(url_tuple._replace(query=query))
 

--- a/federated_aws_cli/login.py
+++ b/federated_aws_cli/login.py
@@ -350,7 +350,9 @@ class Login:
         url = urlunparse(url_tuple._replace(query=query))
         token = requests.get(url).json()
 
-        issuer_url_query = urlencode({"role_arn": self.role_arn})
+        account_id = self.role_arn.split(":")[4]
+        role = self.role_arn.split(':')[5].split('/')[-1]
+        issuer_url_query = urlencode({"account": account_id, "role": role})
         issuer_url = urlunparse(
             ('https', self.issuer_domain, '/', '', issuer_url_query, ''))
 


### PR DESCRIPTION
This has a default of the Mozilla federated RP. We should probably establish a more centralized method to enumerate defaults. When we do we can move this default there.

This also doesn't do anything for refreshing the CLI session.